### PR TITLE
Make AdfState optional

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,17 +89,20 @@ impl cli::ColorSpace {
     }
 }
 
-fn choose_source(source: cli::Source, adf_state: AdfState) -> Result<InputSource, ScannerError> {
+fn choose_source(
+    source: cli::Source,
+    adf_state: Option<AdfState>,
+) -> Result<InputSource, ScannerError> {
     let input_source = match source {
         cli::Source::auto => {
-            if adf_state == AdfState::Loaded {
+            if adf_state == Some(AdfState::Loaded) {
                 InputSource::Adf
             } else {
                 InputSource::Platen
             }
         }
         cli::Source::adf => {
-            if adf_state == AdfState::Loaded {
+            if adf_state == Some(AdfState::Loaded) {
                 InputSource::Adf
             } else {
                 return Err(ScannerError::AdfEmpty);

--- a/src/web.rs
+++ b/src/web.rs
@@ -187,17 +187,17 @@ fn do_scan(
     }
 }
 
-fn choose_source(source: Source, adf_state: AdfState) -> Result<InputSource, ScannerError> {
+fn choose_source(source: Source, adf_state: Option<AdfState>) -> Result<InputSource, ScannerError> {
     let input_source = match source {
         Source::auto => {
-            if adf_state == AdfState::Loaded {
+            if adf_state == Some(AdfState::Loaded) {
                 InputSource::Adf
             } else {
                 InputSource::Platen
             }
         }
         Source::adf => {
-            if adf_state == AdfState::Loaded {
+            if adf_state == Some(AdfState::Loaded) {
                 InputSource::Adf
             } else {
                 return Err(ScannerError::AdfEmpty);


### PR DESCRIPTION
Hey Armin,
thanks for that great tool!

With this trivial patch, I was able to make it work with an HP DeskJet 3070A, which doesn't have an automatic document feeder.